### PR TITLE
fix: misrepresented battery discharging icon visual + folder path visualization via trail

### DIFF
--- a/chips-double-width.omp.json
+++ b/chips-double-width.omp.json
@@ -13,7 +13,9 @@
           ],
           "leading_diamond": "\uE0B6",
           "properties": {
-            "style": "folder"
+            "style": "agnoster_short",
+            "hide_root_location": true,
+            "max_depth": 2
           },
           "style": "diamond",
           "template": "\uF07B  {{ .Path }}",

--- a/chips-double-width.omp.json
+++ b/chips-double-width.omp.json
@@ -125,7 +125,7 @@
           "foreground": "p:c-badge-text",
           "leading_diamond": "\uE0B6",
           "style": "diamond",
-          "template": "{{ if eq \"True\" (title (default \"False\" .Env.DISABLE_SEGMENT_BATTERY)) }}{{ else }}{{ if not .Error }}{{ if eq \"Charging\" .State.String }}\uF0E7 {{ else if eq \"Discharging\" .State.String }}\uF062 {{ else if eq \"Full\" .State.String }}~ {{ else }}?{{ end }}{{ if le .Percentage 15 }}\uF579{{ else if and (ge .Percentage 16) (le .Percentage 30) }}\uF57A{{ else if and (ge .Percentage 31) (le .Percentage 45) }}\uF57C{{ else if and (ge .Percentage 46) (le .Percentage 55)}}\uF57D{{ else if and (ge .Percentage 56) (le .Percentage 70) }}\uF57E{{ else if and (ge .Percentage 71) (le .Percentage 80) }}\uF580{{ else if and (ge .Percentage 81) (le .Percentage 95) }}\uF581{{ else }}\uF578{{ end }} {{ .Percentage }}%{{ else }}!{{ end }}{{ end }}",
+          "template": "{{ if eq \"True\" (title (default \"False\" .Env.DISABLE_SEGMENT_BATTERY)) }}{{ else }}{{ if not .Error }}{{ if eq \"Charging\" .State.String }}\uF0E7 {{ else if eq \"Discharging\" .State.String }}{{ else if eq \"Full\" .State.String }}~ {{ else }}? {{ end }}{{ if le .Percentage 15 }}\uF579{{ else if and (ge .Percentage 16) (le .Percentage 30) }}\uF57A{{ else if and (ge .Percentage 31) (le .Percentage 45) }}\uF57C{{ else if and (ge .Percentage 46) (le .Percentage 55)}}\uF57D{{ else if and (ge .Percentage 56) (le .Percentage 70) }}\uF57E{{ else if and (ge .Percentage 71) (le .Percentage 80) }}\uF580{{ else if and (ge .Percentage 81) (le .Percentage 95) }}\uF581{{ else }}\uF578{{ end }} {{ .Percentage }}%{{ else }}!{{ end }}{{ end }}",
           "trailing_diamond": "\uE0B4",
           "type": "battery"
         }

--- a/chips-double-width.omp.json
+++ b/chips-double-width.omp.json
@@ -14,6 +14,7 @@
           "leading_diamond": "\uE0B6",
           "properties": {
             "style": "agnoster_short",
+            "folder_separator_icon": "/",
             "hide_root_location": true,
             "max_depth": 2
           },

--- a/chips.omp.json
+++ b/chips.omp.json
@@ -13,7 +13,9 @@
           ],
           "leading_diamond": "\uE0B6",
           "properties": {
-            "style": "folder"
+            "style": "agnoster_short",
+            "hide_root_location": true,
+            "max_depth": 2
           },
           "style": "diamond",
           "template": "\uF07B {{ .Path }}",
@@ -123,7 +125,7 @@
           "foreground": "p:c-badge-text",
           "leading_diamond": "\uE0B6",
           "style": "diamond",
-          "template": "{{ if eq \"True\" (title (default \"False\" .Env.DISABLE_SEGMENT_BATTERY)) }}{{ else }}{{ if not .Error }}{{ if eq \"Charging\" .State.String }}\uE315 {{ else if eq \"Discharging\" .State.String }}\uF062 {{ else if eq \"Full\" .State.String }}~ {{ else }}? {{ end }}{{ if le .Percentage 15 }}\uF579{{ else if and (ge .Percentage 16) (le .Percentage 30) }}\uF57A{{ else if and (ge .Percentage 31) (le .Percentage 45) }}\uF57C{{ else if and (ge .Percentage 46) (le .Percentage 55)}}\uF57D{{ else if and (ge .Percentage 56) (le .Percentage 70) }}\uF57E{{ else if and (ge .Percentage 71) (le .Percentage 80) }}\uF580{{ else if and (ge .Percentage 81) (le .Percentage 95) }}\uF581{{ else }}\uF578{{ end }} {{ .Percentage }}%{{ else }}!{{ end }}{{ end }}",
+          "template": "{{ if eq \"True\" (title (default \"False\" .Env.DISABLE_SEGMENT_BATTERY)) }}{{ else }}{{ if not .Error }}{{ if eq \"Charging\" .State.String }}\uE315 {{ else if eq \"Discharging\" .State.String }}{{ else if eq \"Full\" .State.String }}~ {{ else }}? {{ end }}{{ if le .Percentage 15 }}\uF579{{ else if and (ge .Percentage 16) (le .Percentage 30) }}\uF57A{{ else if and (ge .Percentage 31) (le .Percentage 45) }}\uF57C{{ else if and (ge .Percentage 46) (le .Percentage 55)}}\uF57D{{ else if and (ge .Percentage 56) (le .Percentage 70) }}\uF57E{{ else if and (ge .Percentage 71) (le .Percentage 80) }}\uF580{{ else if and (ge .Percentage 81) (le .Percentage 95) }}\uF581{{ else }}\uF578{{ end }} {{ .Percentage }}%{{ else }}!{{ end }}{{ end }}",
           "trailing_diamond": "\uE0B4",
           "type": "battery"
         }

--- a/chips.omp.json
+++ b/chips.omp.json
@@ -14,6 +14,7 @@
           "leading_diamond": "\uE0B6",
           "properties": {
             "style": "agnoster_short",
+            "folder_separator_icon": "/",
             "hide_root_location": true,
             "max_depth": 2
           },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Non-Standard Compliant Material Design-Inspired Chips Theme for Oh-My-Posh Theme.",
   "scripts": {
     "copy-local": "pwsh -NoProfile -Command Copy-Item -Destination \"./\" -Path \"~/chips.omp.json\" -Confirm",
-    "copy-local-double-width": "pwsh -NoProfile -Command Copy-Item -Destination \"./\" -Path \"~/chips-double-width.omp.json\" -Confirm",
+    "copy-local-double-width": "pwsh -NoProfile -Command Copy-Item -Destination \"./chips-double-width.omp.json\" -Path \"~/chips.omp.json\" -Confirm",
     "copy-git": "pwsh -NoProfile -Command Copy-Item -Destination \"~/\" -Path \"chips.omp.json\"  -Confirm",
     "copy-git-double-width": "pwsh -NoProfile -Command Copy-Item -Destination \"~/chips.omp.json\" -Path \"chips-double-width.omp.json\"  -Confirm",
     "snapshot-local-ref": "pwsh -Command Write-Host \"oh-my-posh config export image --author 'CodexLink, More Samples at https://github.com/CodexLink/chips.omp.json' --config ~/chips.omp.json --cursor-padding 20 --rprompt-offset 20 --output highlight.png\"",


### PR DESCRIPTION
## Introduction

This PR fixes the misrepresentation of a discharging state of a battery by literally deleting it or displaying nothing as the default display of the battery does not infer anything aside from discharging when they are not in a charging state, obviously.

- Refers to #9

Also, this PR acknowledges the change for the folder path visual display; I, too get incredibly confused navigating through folders of a folder so I agree with adding trail structure from the visual on the segment. A proposal for deploying multiple variants (with the addition of a `simple` variant aside from `double-width`) has been made during the mentioned PR below for discussion, but I got no response to it.

- Refers to https://github.com/JanDeDobbeleer/oh-my-posh/pull/3990 and #8 